### PR TITLE
[1주차] 이론과제 + 실습과제 리뷰 - 예린

### DIFF
--- a/src/main/java/mataedu/jpastudy/repository/UserJpqlRepository.java
+++ b/src/main/java/mataedu/jpastudy/repository/UserJpqlRepository.java
@@ -1,40 +1,42 @@
 package mataedu.jpastudy.repository;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityTransaction;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import mataedu.jpastudy.entity.User;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
+@Transactional
 public class UserJpqlRepository {
 
-    @PersistenceContext // EntityManager 자동 주입 =>  스프링이 관리하는 EntityManager
+    //@PersistenceContext // EntityManager 자동 주입 =>  스프링이 관리하는 EntityManager RAC 덕분에 안해도 됨.
     private final EntityManager entityManager;
+    //private final JdbcTemplate jdbcTemplate;
 
     public User saveUser(User user) {
-        EntityTransaction transaction = entityManager.getTransaction();
-        try {
-            transaction.begin(); //트랜젝션 시작
-            entityManager.persist(user);
-            transaction.commit(); //commit query
-            return user;
-        } catch (Exception e) {
-            transaction.rollback();
-            throw new IllegalArgumentException("저장에 실패했습니다.");
-        }
+        entityManager.persist(user);
+        return user;
     }
 
+    //JPQL
     public List<User> findUserName(String name) {
-        return entityManager.createQuery("select u.name from User u where u.name = :name", User.class)
+        return entityManager.createQuery("select u from User u where u.name = :name", User.class)
                 .setParameter("name", name)
                 .getResultList();
     }
+
+    //JDBC
+//    public List<User> findUserNameToJDBC(String name) {
+//        String sql = "SELECT * FROM users WHERE name = ?";
+//        return jdbcTemplate.query(sql, new Object[]{name}, new UserRowMapper());
+//    }
+
 
     public Optional<User> findById(Long id) {
         return Optional.ofNullable(entityManager.find(User.class, id));

--- a/src/main/java/mataedu/jpastudy/repository/UserRepository.java
+++ b/src/main/java/mataedu/jpastudy/repository/UserRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface UserRepository extends JpaRepository<User, Long> {
-
-
+    User findByName(String name);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,12 @@
 spring.application.name=jpa-study
 
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:h2:mem:test
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create
+
+logging.level.org.hibernate.SQL=debug
+#log ?? ??? ??
+spring.jpa.properties.hibernate.format_sql = true

--- a/src/test/java/mataedu/jpastudy/repository/UserJpqlRepositoryTest.java
+++ b/src/test/java/mataedu/jpastudy/repository/UserJpqlRepositoryTest.java
@@ -1,6 +1,5 @@
 package mataedu.jpastudy.repository;
 
-import jakarta.persistence.EntityManager;
 import mataedu.jpastudy.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,14 +18,11 @@ class UserJpqlRepositoryTest {
     @Autowired
     private UserJpqlRepository userJpqlRepository;
 
-    @Autowired
-    private EntityManager em;
     @Test
     @DisplayName("JPQL로 유저를 저장한다.")
     void save() {
         // given
         User user = User.builder()
-                .id(1L)
                 .name("test")
                 .email("test@test.com")
                 .build();
@@ -36,7 +32,6 @@ class UserJpqlRepositoryTest {
 
         // then
         assertThat(saveUser.getId()).isNotNull();
-
     }
 
     @Test

--- a/src/test/java/mataedu/jpastudy/repository/UserRepositoryTest.java
+++ b/src/test/java/mataedu/jpastudy/repository/UserRepositoryTest.java
@@ -21,8 +21,9 @@ class UserRepositoryTest {
     @DisplayName("유저를 저장한다.")
     void addUser() {
         // given
+        // 아이디가 있으면 select 쿼리가 나감
         User user = User.builder()
-                .id(1L)
+               // .id(1L)
                 .name("test")
                 .email("test@test.com")
                 .build();
@@ -32,7 +33,6 @@ class UserRepositoryTest {
 
         // then
         assertThat(saveUser.getId()).isNotNull();
-
     }
 
     @Test


### PR DESCRIPTION
관련이슈 : 1주차 이론과제 (#5) 

### 이론과제 답변

1.  ORM과 JDBC의 차이점과 JPA가 실무에서 왜 사용되는 이유.
- JDBC는 직접 조회쿼리등을 작성해서 수동적인 작업들이 많이 발생하는 단점이 있음.

2. 영속성 컨텍스트란 무엇이며 왜 필요한가? 
영속성 컨텍스트란 JPA에서 엔티티 객체를 관리하는 일종의 중간 저장장소(캐시) 
같은 트렌젝션일 경우 데이터베이스가 아닌 1차 캐시안에 있는 값을 반환하여 성능에 도움이 됨
변경 감지 (Dirty Checking)을 통해 변경내용을 자동으로 반영함. update 쿼리가 필요 없음.



**변천사 … JDBC ⇒ JPA=ORM ⇒JPQL ⇒ Spring Data Jpa** 
  ```
   // Spring Data Jpa
    public interface UserRepository extends JpaRepository<User, Long> {
    User findByName(Sting name)
}

    ------------------------------------------------------------------------------
    
    // JPQL
     public List<User> findUserName(String name) { 
        return entityManager.createQuery("select u from User u where u.name = :name", User.class)
                .setParameter("name", name)
                .getResultList();
    }
    
    //JPA ===== ORM
     public List<User> findUserName(String name) { // JPQL
        return entityManager.createQuery("select u from User u where u.name = :name", User.class)
                .setParameter("name", name)
                .getResultList();
    }

    
    ------------------------------------------------------------------------------
    // JDBC
    //전부 수정이 필요함
    public List<User> findUserName(String name) { 
        String sql = "SELECT * FROM users WHERE name = ?";
        return jdbcTemplate.query(sql, new Object[]{name}, new UserRowMapper());
    }
    
    //객체로 변환하는 것도 필요
        private static class UserRowMapper implements RowMapper<User> {
        @Override
        public User mapRow(ResultSet rs, int rowNum) throws SQLException {
            return User.builder()
                    .id(rs.getLong("id"))
                    .name(rs.getString("name"))
                    .email(rs.getString("email"))
                    .build();
        }
    }
```


### 과제 리뷰

관련 PR : 1주차 실습과제 제출(#2 )

오류상황 1
Repository테스트 코드 작성중 오류 발생
Not allowed to create transaction on shared EntityManager - use Spring transactions or EJB CMT instead

원인 : 직접 트랜젝션을 조작하려고 함 
@Autowired에 의해 EntityManager 가 싱글톤으로 관리되고 있어 테스트코드에서 문제 발생...
```
 public User saveUser(User user) {
        EntityTransaction transaction = entityManager.getTransaction();
        try {
            transaction.begin(); //트랜젝션 시작
            entityManager.persist(user);
            transaction.commit(); //commit query
            return user;
        } catch (Exception e) {
            transaction.rollback();
            throw new IllegalArgumentException("저장에 실패했습니다.");
        }
    }
```
해결: 직접 트랜젝션 조작을 하지 않고 @ Transactional 어노테이션 사용.
++ 추가로 try catch 문을 제거함으로서 좀 더 정확한 오류 메세지를 확인 할 수 있었음.

오류상황 2
- UserJpqlRepository 테스트 코드 작성중 오류 메세지 발생 : detached entity passed to persist: mataedu.jpastudy.entity.User
원인: 객체 생성시 .id(1L) 를 설정했기  때문.
JPA의 경우 Id를 넣어 객체를 생성, 저장 할경우 먼저 db에 있는지 selete를 하고 있으면 update를 함.
JPQL의 경우 id 값을 지정하면 오류 발생 (하지만 실 서비스에서 key값을 직접 넣는 경우는 없으니 테스트 코드여서 발생한 문제라고 볼수 있음)
```
@SpringBootTest
@Transactional
class UserJpqlRepositoryTest {

    @Autowired
    private UserJpqlRepository userJpqlRepository;

    @Test
    @DisplayName("JPQL로 유저를 저장한다.")
    void save() {
        // given
        User user = User.builder()
                .name("test")
                .email("test@test.com")
                .build();

```